### PR TITLE
add initial `pyproject.toml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 This package provides the `better_teleop.py` script which allows sending velocity commands to a robot using the keyboard's arrow keys without a terminal window being in focus.
 
-The package utilizes the `pynput` Python package which needs to be installed manually via
+The package utilizes the `pynput` Python package. The dependency can be installed using:
 
-```
-sudo pip install pynput
+```bash
+pip install .
 ```
 
 The node is launched via
 
-```
+```bash
 roslaunch better_teleop better_teleop.launch
 ```
 
-The launch file also contains the parameters of the script which are the topic onto which to publish velcoity commands (`cmd_topic`), as well as the rates to use when computing the command to send, i.e. `forward_rate, backward_rate, rotation_rate`.
+The launch file also contains the parameters of the script which are the topic onto which to publish velocity commands (`cmd_topic`), as well as the rates to use when computing the command to send, i.e. `forward_rate, backward_rate, rotation_rate`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "better_teleop"
+version = "1.0.0"
+description = "Simple ROS keyboard-based teleoperation node"
+readme = "README.md"
+license = {file = "LICENSE"}
+
+authors = [
+    {name = "Lionel Ott", email = "lioott@ethz.ch"},
+]
+
+dependencies = [
+    "pynput",
+]
+
+[project.urls]
+repository = "https://github.com/ethz-asl/better_teleop.git"


### PR DESCRIPTION
this adds a [PEP 621] compatible [`pyproject.toml`].

this then allows running `pip install .` which would install the project itself as well as its dependencies.
as the project doesn't have a `src/better_teleop` folder but instead only contains `scripts/` nothing is installed for the project, but its dependencies are nevertheless being installed.

the alternative to this would be to use a `requirements.txt` and then require the users to run `pip install -r requirements.txt`. i've prepared this in PR #1, but feel that this here is the better, more modern and more extensible approach.

full disclosure: this is the first time i'm adding a `pyproject.toml` - i'm not exactly familiar with python projects!

[PEP 621]: https://peps.python.org/pep-0621/
[`pyproject.toml`]: https://packaging.python.org/en/latest/specifications/declaring-project-metadata/